### PR TITLE
Update about page to reflect new title and slogan

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -46,7 +46,7 @@ export default function About() {
             </p>
 
             <p className="select-none text-justify text-sm sm:text-base md:text-lg lg:text-xl">
-              {about.description}
+              {about.slogan}
             </p>
 
             <div className="m-2">

--- a/public/infos/about.tsx
+++ b/public/infos/about.tsx
@@ -1,7 +1,7 @@
 export const about = {
     firstname: "Yun Ji",
     lastname: "How",
-    title: "Aspiring Software Engineer",
+    title: "Software Engineer",
     status: "Looking for new opportunities.",
     slogan: "Starting Small, Dreaming Big.",
     description: "Passionate about software engineering, ready to apply skills in practical software development environments.",


### PR DESCRIPTION
This pull request includes changes to the `app/about/page.tsx` and `public/infos/about.tsx` files to update the displayed information on the About page. The most important changes include replacing the `description` with a `slogan` and updating the title.

Updates to displayed information:

* [`app/about/page.tsx`](diffhunk://#diff-06f49e3158547ee7b6e5ad074bcb5d474ecd3b8d7b1418c4ab1d89973e22c5edL49-R49): Changed the displayed text from `about.description` to `about.slogan`.
* [`public/infos/about.tsx`](diffhunk://#diff-0f2143d21e22485528708e17e78313ce890af1d5baf6ef8522686b8041fb0ceeL4-R4): Updated the `title` from "Aspiring Software Engineer" to "Software Engineer".