### PR TITLE
fix: update LinkedIn link in contactList

### DIFF
--- a/public/infos/contact.tsx
+++ b/public/infos/contact.tsx
@@ -19,7 +19,7 @@ export const contactList = [
     },
     {
         name: "LinkedIn",
-        link: "https://www.linkedin.com/in/yun-ji-how-64025220a/",
+        link: "https://www.linkedin.com/in/yunjih/",
         username: "Yun Ji How",
         iconPath: "/icons/linkedin.png",
         iconLight: "/icons/linkedinLight.png",


### PR DESCRIPTION
This pull request includes a minor update to the LinkedIn profile link in the `contactList` export in `public/infos/contact.tsx`. The change replaces the old URL with a corrected and updated LinkedIn profile link.